### PR TITLE
Runner node selector

### DIFF
--- a/kubernetes/deployments/runner.yaml
+++ b/kubernetes/deployments/runner.yaml
@@ -37,3 +37,5 @@ spec:
         ports:
           - name: http
             containerPort: 8088
+      nodeSelector:
+        runner: true

--- a/rabbitmq_send.py
+++ b/rabbitmq_send.py
@@ -2,8 +2,9 @@
 import sys
 
 import pika
+from config import QUEUE_URL
 
-connection = pika.BlockingConnection(pika.ConnectionParameters(host="localhost"))
+connection = pika.BlockingConnection(pika.URLParameters(QUEUE_URL))
 channel = connection.channel()
 
 channel.queue_declare(queue="hello", durable=True, arguments={"x-message-ttl": 3600000})


### PR DESCRIPTION
Force runner pod to run on a different node than the db. We have been experiencing some problems in the db caused by the runner running out of memory. 