### PR TITLE
Remove liveness

### DIFF
--- a/kubernetes/deployments/runner.yaml
+++ b/kubernetes/deployments/runner.yaml
@@ -36,12 +36,6 @@ spec:
           limits:
             cpu: 300m
             memory: 400Mi
-        livenessProbe:
-          initialDelaySeconds: 40
-          periodSeconds: 60
-          httpGet:
-            path: /health
-            port: 8000
         readinessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60


### PR DESCRIPTION
When having multiple submissions the runner was not being able to respond to the `/health` endpoint. Meanwhile, we remove the livenessProbe until we find another solution.