### PR TITLE
Fix bug while logging RunnerError

### DIFF
--- a/rpl_runner/init.py
+++ b/rpl_runner/init.py
@@ -81,7 +81,7 @@ def process(lang, test_mode, filename, cflags=""):
                 result["test_run_result"] = "ERROR"
                 result["test_run_stage"] = e.stage
                 result["test_run_exit_message"] = e.message
-                LOG.error("HUBO ERRORES :))))))", e.message, "en la etapa:", e.stage)
+                LOG.error("HUBO ERRORES: {message} en la etapa de {stage}".format(message=e.message, stage=e.stage))
             except Exception as e:
                 result["test_run_result"] = "UNKNOWN_ERROR"
                 result["test_run_stage"] = "unknown"


### PR DESCRIPTION
We were not handling `RunnerError` as expected, causing an unexpected error and leaving some submissions in `PROCESSING`. 

Example:
https://console.cloud.google.com/logs/query;pinnedLogId=2020-10-21T23:16:50.900475145Z%2F19lvvgogivqomxow9;query=labels.%22k8s-pod%2Fapp%22%20%3D%20%22runner%22%0A;summaryFields=:true:32:beginning;timeRange=2020-10-21T23:15:37Z%2F2020-10-21T23:17:01Z?project=fiuba-rpl

This error was caused because we were trying to concatenate a string with special characters. 