### PR TITLE
Separate CFLAGS into CFLAGS and LDFLAGS

### DIFF
--- a/rpl_runner/c_Makefile
+++ b/rpl_runner/c_Makefile
@@ -15,13 +15,13 @@ run:
 
 # Build only student files so we get a nice error message
 build_pre_unit_test: $(ARCHIVOS_SIN_UNIT_TEST)
-	$(CC) ${CFLAGS} -c $^
+	$(CC) ${CFLAGS} -c $^ ${LDFLAGS}
 
 
 # Build with criterion lib and delete source files so students can't read and print test cases
 # @ --> don't print command to stdout
 build_unit_test: $(ARCHIVOS:.c=.o)
-	$(CC) ${CFLAGS} -o main $^ -lcriterion
+	$(CC) ${CFLAGS} -o main $^ ${LDFLAGS} -lcriterion
 	@rm ${ARCHIVOS}
 
 run_unit_test:

--- a/rpl_runner/init.py
+++ b/rpl_runner/init.py
@@ -49,6 +49,9 @@ def main():
 
 def process(lang, test_mode, filename, cflags=""):
     os.environ["CFLAGS"] = cflags
+    if "-l" in cflags:
+        os.environ["CFLAGS"] = " ".join([x if "-l" not in x else "" for x in cflags.split()])
+        os.environ["LDFLAGS"] = " ".join([x if "-l" in x else "" for x in cflags.split()])
 
     with tempfile.TemporaryDirectory(prefix="corrector.") as tmpdir:
         LOG.info(f"Extracting tarfile submission from {filename}")


### PR DESCRIPTION
We currently can't build programs with libs since all libraries are added at the beginning of the gcc command while they should be added at the end

