### PR TITLE
[RFC] chore: upgrade runner's Python version to 3.10

### DIFF
--- a/rpl_runner/Dockerfile
+++ b/rpl_runner/Dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 RUN apt-get update     && \
     apt-get upgrade -y && \
     apt-get install -y gcc gcc-multilib g++ clang      	\
-                       make valgrind time python3.7 	\
-                       python3.7-dev libgtest-dev       \
+                       make valgrind time python3.10 	\
+                       python3.10-dev libgtest-dev       \
                        python3-pip git
 
 # Fix for installing flask in ubuntu:bionic
 RUN apt-get install -y python3-markupsafe
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 
 RUN pip3 install timeout-decorator
 RUN pip3 install flask gunicorn

--- a/rpl_runner/init.py
+++ b/rpl_runner/init.py
@@ -128,7 +128,7 @@ def parse_stdout(log_stdout):
             result = ""
 
         elif (
-            "/usr/bin/python3.7" in line
+            "custom_IO_main.pyc" in line
             or "assignment_main.py" in line
             or "./main" in line
         ):

--- a/rpl_runner/python_Makefile
+++ b/rpl_runner/python_Makefile
@@ -4,13 +4,13 @@ ARCHIVOS = $(wildcard *.py)
 # Then create binary and delete source files so students can't read and print test cases
 # @ --> don't print command to stdout
 build_io: $(ARCHIVOS)
-	/usr/bin/python3.7 /usr/custom_compileall.py
+	/usr/bin/python3.10 /usr/custom_compileall.py
 
 build_unit_test: $(ARCHIVOS)
-	/usr/bin/python3.7 /usr/custom_compileall.py
+	/usr/bin/python3.10 /usr/custom_compileall.py
 
 run:
-	/usr/bin/python3.7 custom_IO_main.pyc
+	/usr/bin/python3.10 custom_IO_main.pyc
 
 run_unit_test:
-	/usr/bin/python3.7 unit_test_wrapper.pyc
+	/usr/bin/python3.10 unit_test_wrapper.pyc


### PR DESCRIPTION
En Algoritmos I estamos enseñando tipado con los [cambios aplicados por Python 3.9](https://peps.python.org/pep-0585/). Esto no es compatible con el Python 3.7 usado actualmente por el Runner de RPL, entonces cuando los estudiantes quieren usar tipado del estilo `def f(args: list[str])`, les rompe con un error bastante confuso.

El PR actualiza la versión de Python a la versión 3.10. También cambia la imagen de docker base hacia Ubuntu 22 LTS.

Al incluir un `import sys; print(sys.version)` en una entrega, se ve lo siguiente:

![image](https://github.com/reinvent-fiuba/RPL-2.0-runner/assets/4763786/8effe559-3551-40e2-bf0a-52537beb0747)


### Antes de mergear, revisar lo siguiente

- [ ] Se probaron simples ejercicios de entrada/salida y de tests unitarios para todos los lenguajes en un entorno local end2end. ¿Hay alguna otra prueba del lado del runner que se pueda ejecutar?
- [ ] Hasta donde puedo ver, la única referencia a Python 3.7 en los otros repositorios es en el servicio principal/producer para filtrar la el stdout final ([aquí su PR](https://github.com/reinvent-fiuba/RPL-2.0/pull/100) para retocarlo). ¿Hay algún otro lugar que requiera cambios?